### PR TITLE
Maven version 3.6.0 to 3.8.1

### DIFF
--- a/10/maven/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/10/maven/ubuntu/Dockerfile.hotspot.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk10:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/10/maven/ubuntu/Dockerfile.hotspot.releases.full
+++ b/10/maven/ubuntu/Dockerfile.hotspot.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk10:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/10/maven/ubuntu/Dockerfile.openj9.nightly.full
+++ b/10/maven/ubuntu/Dockerfile.openj9.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk10-openj9:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/10/maven/ubuntu/Dockerfile.openj9.releases.full
+++ b/10/maven/ubuntu/Dockerfile.openj9.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk10-openj9:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/11/maven/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/11/maven/ubuntu/Dockerfile.hotspot.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk11:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/11/maven/ubuntu/Dockerfile.hotspot.releases.full
+++ b/11/maven/ubuntu/Dockerfile.hotspot.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk11:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/11/maven/ubuntu/Dockerfile.openj9.nightly.full
+++ b/11/maven/ubuntu/Dockerfile.openj9.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk11-openj9:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/11/maven/ubuntu/Dockerfile.openj9.releases.full
+++ b/11/maven/ubuntu/Dockerfile.openj9.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk11-openj9:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/8/maven/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/8/maven/ubuntu/Dockerfile.hotspot.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk8:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/8/maven/ubuntu/Dockerfile.hotspot.releases.full
+++ b/8/maven/ubuntu/Dockerfile.hotspot.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk8:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/8/maven/ubuntu/Dockerfile.openj9.nightly.full
+++ b/8/maven/ubuntu/Dockerfile.openj9.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk8-openj9:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/8/maven/ubuntu/Dockerfile.openj9.releases.full
+++ b/8/maven/ubuntu/Dockerfile.openj9.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk8-openj9:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/9/maven/ubuntu/Dockerfile.hotspot.nightly.full
+++ b/9/maven/ubuntu/Dockerfile.hotspot.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk9:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/9/maven/ubuntu/Dockerfile.hotspot.releases.full
+++ b/9/maven/ubuntu/Dockerfile.hotspot.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk9:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/9/maven/ubuntu/Dockerfile.openj9.nightly.full
+++ b/9/maven/ubuntu/Dockerfile.openj9.nightly.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk9-openj9:nightly
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \

--- a/9/maven/ubuntu/Dockerfile.openj9.releases.full
+++ b/9/maven/ubuntu/Dockerfile.openj9.releases.full
@@ -21,9 +21,9 @@ FROM adoptopenjdk/openjdk9-openj9:latest
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-ARG MAVEN_VERSION="3.6.0"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \


### PR DESCRIPTION
Maven 3.6.0 has security vulnerability and due to this some projects are requiring min maven version of 3.8.1
https://nvd.nist.gov/vuln/detail/CVE-2021-26291
https://maven.apache.org/docs/3.8.1/release-notes.html
