### PR TITLE
Maven Version missmatch between Dockerfiles and docker_functions.sh

### DIFF
--- a/dockerfile_functions.sh
+++ b/dockerfile_functions.sh
@@ -78,9 +78,9 @@ print_base_java() {
 print_maven() {
 	cat >> $1 <<'EOI'
 
-ARG MAVEN_VERSION="3.6.3"
+ARG MAVEN_VERSION="3.8.1"
 ARG USER_HOME_DIR="/root"
-ARG SHA="26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5"
+ARG SHA="b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
 ARG BASE_URL="https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries"
 
 RUN mkdir -p /usr/share/maven \


### PR DESCRIPTION
Dockerfiles files showing 3.8.1 but docker_functions.sh using 3.6.3. Updated docker_funcitons.sh to reflect correct version.